### PR TITLE
Change default atlas size from 4096x4096 to 1024x1024

### DIFF
--- a/ModTheGungeonAPI/ETGMod/Assets/RuntimeAtlas.cs
+++ b/ModTheGungeonAPI/ETGMod/Assets/RuntimeAtlas.cs
@@ -85,7 +85,7 @@ public class RuntimeAtlasPacker
 /// </summary>
 public class RuntimeAtlasPage
 {
-    public static int DefaultSize = Math.Min(SystemInfo.maxTextureSize, 4096);
+    public static int DefaultSize = Math.Min(SystemInfo.maxTextureSize, 1024);
 
     public List<RuntimeAtlasSegment> Segments = new List<RuntimeAtlasSegment>();
     public Texture2D Texture;


### PR DESCRIPTION
Change default atlas size from 4096x4096 to 1024x1024 to reduce memory consumption and prevent graphics card crashes.