### PR TITLE
SGUI memory leak fixes

### DIFF
--- a/ModTheGungeonAPI/ETGMod/SGUI/Elements/SGroup.cs
+++ b/ModTheGungeonAPI/ETGMod/SGUI/Elements/SGroup.cs
@@ -103,6 +103,8 @@ namespace SGUI {
             Draw.Rect(this, Position, Size, Background);
         }
         public override void Render() {
+            if (!Visible)
+                return;
             if (Backend.ScrollBarSizes.x == 0f && ScrollDirection != EDirection.None) {
                 ScrollPosition = new Vector2(
                     Mathf.Clamp(ScrollPosition.x + ScrollMomentum.x, 0f, ContentSize.x - Size.x),

--- a/ModTheGungeonAPI/ETGMod/SGUI/SElement.cs
+++ b/ModTheGungeonAPI/ETGMod/SGUI/SElement.cs
@@ -259,14 +259,15 @@ namespace SGUI {
                 Background = color;
             }
 
-            Modifiers.ForEach(_ModifierUpdateStyle);
+            for (int i = 0; i < Modifiers.Count; ++i)
+            {
+                Modifiers[i].Elem = this;
+                Modifiers[i].UpdateStyle();
+            }
             if (OnUpdateStyle != null) OnUpdateStyle(this);
             UpdateChildrenStyles();
         }
-        protected void _ModifierUpdateStyle(SModifier modifier) {
-            modifier.Elem = this;
-            modifier.UpdateStyle();
-        }
+
         public virtual void UpdateChildrenStyles() {
             for (int i = 0; i < Children.Count; i++) {
                 SElement child = Children[i];
@@ -278,13 +279,14 @@ namespace SGUI {
         }
 
         public virtual void Update() {
-            Modifiers.ForEach(_ModifierUpdate);
+            for (int i = 0; i < Modifiers.Count; ++i)
+            {
+                Modifiers[i].Elem = this;
+                Modifiers[i].Update();
+            }
             UpdateChildren();
         }
-        protected void _ModifierUpdate(SModifier modifier) {
-            modifier.Elem = this;
-            modifier.Update();
-        }
+
         public void UpdateChildren() {
             for (int i = 0; i < Children.Count; i++) {
                 SElement child = Children[i];


### PR DESCRIPTION
Fix two large SGUI memory leaks (~500MB / minute):
- don't render invisible `SGroup`s
- replace `ForEach()` methods with `for` loops

Fix a few smaller SGUI memory leaks (~30 MB / minute):
- cache `StringBuilder` used for text measurement
- don't set `Skin.font` if it hasn't actually changed
- don't use nullable value types in `Text_()`

![roto](https://github.com/user-attachments/assets/1b949889-4634-4235-9ffe-40e33f3acc2b)